### PR TITLE
Create Dockerfile for easy setup and execution

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,44 @@
+# Use a Miniconda base image
+FROM continuumio/miniconda3:latest
+
+# Set non-interactive frontend for package installation
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y \
+    wget \
+    unzip \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Copy the entire repository to /propermab
+COPY . /propermab
+WORKDIR /propermab
+
+# Create the conda environment
+RUN conda env create -f conda_env.yml
+
+# Activate the conda environment and install the propermab package
+SHELL ["conda", "run", "-n", "propermab", "/bin/bash", "-c"]
+RUN pip install -e .
+
+# Download and install external dependencies
+RUN mkdir -p /opt/apbs && \
+    wget https://github.com/Electrostatics/apbs/releases/download/v3.0.0/APBS-3.0.0_Linux.zip -O /opt/apbs/apbs.zip && \
+    unzip /opt/apbs/apbs.zip -d /opt/apbs && \
+    rm /opt/apbs/apbs.zip
+
+RUN mkdir -p /opt/propermab_data && \
+    wget https://electrostaticszone.eu/downloads/scripts-and-utilities/15-pdb2xyzr/pdb2xyzr.zip -O /opt/propermab_data/pdb2xyzr.zip && \
+    unzip /opt/propermab_data/pdb2xyzr.zip -d /opt/propermab_data && \
+    mv /opt/propermab_data/pdb2xyzr/amber.siz /opt/propermab_data/amber.siz && \
+    rm -rf /opt/propermab_data/pdb2xyzr.zip /opt/propermab_data/pdb2xyzr
+
+# Copy the entrypoint script and make it executable
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+# Expose the Jupyter Notebook port
+EXPOSE 8888
+
+# Set the entrypoint
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/conda_env.yml
+++ b/conda_env.yml
@@ -17,6 +17,9 @@ dependencies:
   - seaborn>=0.11
   - numba>=0.50
   - pdb2pqr
+  - hmmer
+  - readline=7.0
+  - jupyter
   - pip
   - pip:
     - immunebuilder>=0.0.5,<=0.0.8

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -e
+
+# Activate conda environment
+source /opt/conda/etc/profile.d/conda.sh
+conda activate propermab
+
+# Determine paths
+HMMER_BIN_PATH=$(dirname $(which hmmscan))
+CONDA_LIB_PATH=${CONDA_PREFIX}/lib
+
+# Create config.json
+cat <<EOF > /propermab/config.json
+{
+    "hmmer_binary_path" : "${HMMER_BIN_PATH}",
+    "nanoshaper_binary_path" : "/opt/apbs/APBS-3.0.0.Linux/bin/NanoShaper",
+    "apbs_binary_path" : "/opt/apbs/APBS-3.0.0.Linux/bin/apbs",
+    "pdb2pqr_path" : "pdb2pqr",
+    "multivalue_binary_path" : "/opt/apbs/APBS-3.0.0.Linux/share/apbs/tools/bin/multivalue",
+    "immunebuilder_weights_dir" : null,
+    "atom_radii_file" : "/opt/propermab_data/amber.siz",
+    "apbs_ld_library_paths" : ["${CONDA_LIB_PATH}", "/opt/apbs/APBS-3.0.0.Linux/lib/"]
+}
+EOF
+
+# Update propermab's default config to use the new config file
+# The example in the README shows doing this from python, so we will do it here.
+# The working directory for jupyter will be /propermab
+cd /propermab
+# The config file will be loaded by the user in their notebook as per the README example.
+
+echo "Starting Jupyter Notebook server..."
+# Execute the command provided to the docker run command
+exec jupyter notebook --ip=0.0.0.0 --port=8888 --no-browser --allow-root --NotebookApp.token='' --NotebookApp.password='' --notebook-dir=/propermab


### PR DESCRIPTION
This commit introduces a Dockerfile and supporting scripts to allow users to easily run the propermab project in a containerized environment.

The key additions are:
- A `Dockerfile` that sets up a conda environment, installs all Python and system dependencies, and downloads external tools like APBS.
- An `entrypoint.sh` script that automatically generates the necessary `config.json` file at container startup with the correct paths for the containerized environment.
- The `conda_env.yml` file has been updated to include `jupyter`, `hmmer`, and `readline=7.0` to ensure the environment is complete.

This allows users to get started with the project by simply building and running the Docker container, which launches a Jupyter Notebook server, without needing to perform the complex local installation described in the README.